### PR TITLE
Better non-JSON response handling

### DIFF
--- a/graphite_checker.go
+++ b/graphite_checker.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -383,6 +384,10 @@ func (c *Check) DoCheck(w http.ResponseWriter) {
 	s.Code = resp.StatusCode
 	if resp.Header.Get("Content-Type") != "application/json" {
 		s.Message = "Non-JSON response from Graphite (exception?)"
+		buf := make([]byte, 5000)
+		if n, err := io.ReadFull(resp.Body, buf); n == len(buf) || err == io.ErrUnexpectedEOF {
+			s.Message += "\n\n" + string(buf)
+		}
 		return
 	}
 	decoder := json.NewDecoder(resp.Body)

--- a/graphite_checker.go
+++ b/graphite_checker.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -385,7 +384,7 @@ func (c *Check) DoCheck(w http.ResponseWriter) {
 	s.Code = resp.StatusCode
 	if resp.Header.Get("Content-Type") != "application/json" {
 		s.Message = "Non-JSON response from Graphite (exception?)"
-		if body, err := ioutil.ReadAll(resp.Body); err != nil {
+		if body, err := ioutil.ReadAll(resp.Body); err == nil {
 			s.Message += "\n\n" + string(body)
 		}
 		return

--- a/graphite_checker.go
+++ b/graphite_checker.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -384,9 +385,8 @@ func (c *Check) DoCheck(w http.ResponseWriter) {
 	s.Code = resp.StatusCode
 	if resp.Header.Get("Content-Type") != "application/json" {
 		s.Message = "Non-JSON response from Graphite (exception?)"
-		buf := make([]byte, 5000)
-		if n, err := io.ReadFull(resp.Body, buf); n == len(buf) || err == io.ErrUnexpectedEOF {
-			s.Message += "\n\n" + string(buf)
+		if body, err := ioutil.ReadAll(resp.Body); err != nil {
+			s.Message += "\n\n" + string(body)
 		}
 		return
 	}


### PR DESCRIPTION
When getting an unexpected response from Graphite, log the full body (up to 5000 bytes) in the response. This is quite helpful for troubleshooting.